### PR TITLE
Expose emergency heat as a switch

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,12 @@
         "description": "Enable switch to get/set the Away state of thermostats found in Daikin account.",
         "type": "boolean",
         "default": false
+      },
+      "enableEmergencyHeatSwitch": {
+        "title": "Enable Emergency Heat Switch",
+        "description": "Enable switch to request auxiliary/emergency heat only",
+        "type": "boolean",
+        "default": false
       }
     }
   },
@@ -111,7 +117,8 @@
         "ignoreOutdoorAqi",
         "ignoreIndoorHumSensor",
         "ignoreOutdoorHumSensor",
-        "enableAwaySwitch"
+        "enableAwaySwitch",
+        "enableEmergencyHeatSwitch"
       ]
     }]
 }

--- a/src/platformEmergencyHeatSwitch.ts
+++ b/src/platformEmergencyHeatSwitch.ts
@@ -1,0 +1,66 @@
+import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { DaikinApi, TargetHeatingCoolingState } from './daikinapi';
+
+import { DaikinOnePlusPlatform } from './platform';
+
+/**
+ * Emergency Heat Switch
+ * Unfortunately HomeKit does not support an "emergency heat" or "auxiliary heat" mode directly,
+ * so the code works around that by exposing a switch to both control and show the emergency heat
+ * status. "On" means auxiliary heat is being requested by the thermostat.
+ */
+export class DaikinOnePlusEmergencyHeatSwitch {
+  private service: Service;
+  CurrentState!: CharacteristicValue;
+  
+  constructor(
+    private readonly platform: DaikinOnePlusPlatform,
+    private readonly accessory: PlatformAccessory,
+    private readonly deviceId: string,
+    private readonly daikinApi: DaikinApi,
+  ) {
+
+    // set accessory information
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Daikin')
+      .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device.model)
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device.id)
+      .setCharacteristic(this.platform.Characteristic.FirmwareRevision, accessory.context.device.firmwareVersion);
+
+    // you can create multiple services for each accessory
+    this.service = this.accessory.getService(this.platform.Service.Switch) 
+                    || this.accessory.addService(this.platform.Service.Switch);
+
+    // set the service name, this is what is displayed as the default name on the Home app
+    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+
+    this.service.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.handleCurrentStateGet.bind(this))
+      .onSet(this.handleCurrentStateSet.bind(this));
+  }
+
+  updateValues() {
+    const value = this.handleCurrentStateGet();
+    this.service.updateCharacteristic(this.platform.Characteristic.On, value);
+    setTimeout(()=>this.updateValues(), 2000);
+  }
+
+  /**
+   * Handle requests to get the current value of the "On" characteristic
+   */
+  handleCurrentStateGet(): boolean {
+    return (
+      this.daikinApi.deviceHasData(this.deviceId) &&
+      this.daikinApi.getTargetState(this.deviceId) === TargetHeatingCoolingState.AUXILIARY_HEAT
+    );
+  }
+
+  /**
+   * Handle requests to set the "On" characteristic
+   */
+  async handleCurrentStateSet(value: CharacteristicValue) {
+    this.platform.log.debug('Emergency Heat', this.accessory.displayName, '- Set Emergency Heat State:', value);
+    await this.daikinApi.setTargetState(this.deviceId, value ? TargetHeatingCoolingState.AUXILIARY_HEAT : TargetHeatingCoolingState.HEAT);
+  }
+  
+}

--- a/src/platformThermostat.ts
+++ b/src/platformThermostat.ts
@@ -1,5 +1,5 @@
 import { Service, PlatformAccessory, CharacteristicValue} from 'homebridge';
-import { DaikinApi } from './daikinapi';
+import { DaikinApi, TargetHeatingCoolingState } from './daikinapi';
 
 import { DaikinOnePlusPlatform } from './platform';
 
@@ -145,22 +145,22 @@ export class DaikinOnePlusThermostat {
    * Handle requests to get the current value of the "Target Heating Cooling State" characteristic
    */
   handleTargetHeatingCoolingStateGet(): CharacteristicValue {
-    //“mode”: 2 is cool, 3 is auto, 1 is heat, 0 is off, emergency heat is 4
     // set this to a valid value for TargetHeatingCoolingState
     let currentValue = this.platform.Characteristic.TargetHeatingCoolingState.OFF;
     const currentStatus = this.daikinApi.getTargetState(this.deviceId);
     // set this to a valid value for CurrentHeatingCoolingState
     switch(currentStatus){
-      case 1:
+      case TargetHeatingCoolingState.HEAT:
+      case TargetHeatingCoolingState.AUXILIARY_HEAT:
         currentValue = this.platform.Characteristic.TargetHeatingCoolingState.HEAT;
         break;
-      case 2:
+      case TargetHeatingCoolingState.COOL:
         currentValue = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
         break;
-      case 3:
+      case TargetHeatingCoolingState.AUTO:
         currentValue = this.platform.Characteristic.TargetHeatingCoolingState.AUTO;
         break;
-      case 0:
+      case TargetHeatingCoolingState.OFF:
         currentValue = this.platform.Characteristic.TargetHeatingCoolingState.OFF;
         break;
       default:
@@ -254,24 +254,22 @@ export class DaikinOnePlusThermostat {
   async handleTargetHeatingCoolingStateSet(value: CharacteristicValue) {
     this.platform.log.debug('Thermostat', this.accessory.displayName, '- Set TargetHeatingCoolingState:', value);
     this.TargetHeatingCoolingState = value;
-
-    //“mode”: 2 is cool, 3 is auto, 1 is heat, 0 is off, emergency heat is 4
   
     // set this to a valid value for TargetHeatingCoolingState
-    let requestedState = 0; //OFF
+    let requestedState = TargetHeatingCoolingState.OFF;
     // set this to a valid value for CurrentHeatingCoolingState
     switch(value){
       case this.platform.Characteristic.TargetHeatingCoolingState.HEAT:
-        requestedState = 1;
+        requestedState = TargetHeatingCoolingState.HEAT;
         break;
       case this.platform.Characteristic.TargetHeatingCoolingState.COOL:
-        requestedState = 2;
+        requestedState = TargetHeatingCoolingState.COOL;
         break;
       case this.platform.Characteristic.TargetHeatingCoolingState.AUTO:
-        requestedState = 3;
+        requestedState = TargetHeatingCoolingState.AUTO;
         break;
       case this.platform.Characteristic.TargetHeatingCoolingState.OFF:
-        requestedState = 0;
+        requestedState = TargetHeatingCoolingState.OFF;
         break;
     }
   


### PR DESCRIPTION
Emergency Heat is useful for users that have a heat pump and a gas furnace that want to be able to force the gas furnace to turn on. An example use case is in the morning when you want to heat up the house ASAP regardless if the heat pump could/would handle it or not.

Unfortunately HomeKit does not support an "emergency heat" or "auxiliary heat" mode directly, so the code works around that by exposing a switch to both control and show the emergency heat status. On means auxiliary heat is being requested by the thermostat.

![image](https://user-images.githubusercontent.com/691152/146666813-5d198e68-8960-4074-a644-1e0df02715eb.png)
