### PR TITLE
Expose "One Clean" as a fan v2

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,12 @@
         "description": "Enable switch to get/set the Away state of thermostats found in Daikin account.",
         "type": "boolean",
         "default": false
+      },
+      "enableOneCleanFan": {
+        "title": "Enable One Clean Fan",
+        "description": "Enable fan that allows the user to run one clean.",
+        "type": "boolean",
+        "default": false
       }
     }
   },
@@ -111,7 +117,8 @@
         "ignoreOutdoorAqi",
         "ignoreIndoorHumSensor",
         "ignoreOutdoorHumSensor",
-        "enableAwaySwitch"
+        "enableAwaySwitch",
+        "enableOneCleanFan"
       ]
     }]
 }

--- a/src/daikinapi.ts
+++ b/src/daikinapi.ts
@@ -227,6 +227,11 @@ export class DaikinApi{
       return device.data.mode;
     }
 
+    getOneCleanFanActive(deviceId: string): boolean {
+      const device = this._devices.find(e=>e.id===deviceId);
+      return device.data.oneCleanFanActive;
+    }
+
     getTargetTemp(deviceId: string): number {
       const device = this._devices.find(e=>e.id===deviceId);
       switch(device.data.mode){
@@ -381,6 +386,25 @@ export class DaikinApi{
           return true; 
         })
         .catch((error) => this.logError('Error updating target state:', error));
+    }
+
+    async setOneCleanFanActive(deviceId: string, requestedState: boolean): Promise<boolean>{
+      this.log(LoggerLevel.DEBUG, `setOneCleanFanActive-> device:${deviceId}; state:${requestedState}`);
+      const requestedData = {oneCleanFanActive: requestedState};
+
+      return axios.put(`https://api.daikinskyport.com/deviceData/${deviceId}`,
+        requestedData, {
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this._token.accessToken}`,
+          },
+        })
+        .then(res => {
+          this.log(LoggerLevel.DEBUG, 'setOneCleanFanActive-> response: ', res.data);
+          return true;
+        })
+        .catch((error) => this.logError('Error updating one clean fan:', error));
     }
 
     async setDisplayUnits(deviceId: string, requestedUnits: number) : Promise<boolean>{

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -16,6 +16,7 @@ import { DaikinOnePlusAQSensor } from './platformAQI';
 import { DaikinOnePlusHumidity } from './platformHumidity';
 import { DaikinOnePlusAwaySwitch } from './platformAwaySwitch';
 import { DaikinApi, LoggerLevel, LogMessage } from './daikinapi';
+import { DaikinOnePlusOneCleanFan } from './platformOneCleanFan';
 
 /**
  * HomebridgePlatform
@@ -143,7 +144,36 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       this.discoverIndoorHumSensor(device);
       this.discoverOutdoorAqi(device, deviceData);
       this.discoverIndoorAqi(device, deviceData);
-      this.discoverAwaySwitch(device);
+      this.discoverOneCleanFan(device);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private discoverOneCleanFan(device: any) {
+    const uuid = this.api.hap.uuid.generate(`${device.id}_one_clean_fan`);
+    this.log.info('Checking for One Clean Fan...');
+    const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
+
+    if (this.config.enableOneCleanFan) {
+      const dName = this.config.includeDeviceName ? `${device.name} One Clean` : 'One Clean';
+      if (existingAccessory) {
+        // the accessory already exists
+        existingAccessory.displayName = dName;
+        this.log.info('Restoring existing one clean fan from cache:', existingAccessory.displayName);
+        new DaikinOnePlusOneCleanFan(this, existingAccessory, device.id, this.daikinApi);
+      } else {
+        // the accessory does not yet exist, so we need to create it
+        this.log.info('Adding new one clean fan:', dName);
+
+        const accessory = new this.api.platformAccessory(dName, uuid);
+        accessory.context.device = device;
+        new DaikinOnePlusOneCleanFan(this, accessory, device.id, this.daikinApi);
+        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      }
+    } else if (existingAccessory) {
+      //Delete any existing one clean fan
+      this.log.info('Removing one clean fan from cache:', existingAccessory.displayName);
+      this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
     }
   }
 

--- a/src/platformOneCleanFan.ts
+++ b/src/platformOneCleanFan.ts
@@ -1,0 +1,63 @@
+import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { DaikinApi } from './daikinapi';
+
+import { DaikinOnePlusPlatform } from './platform';
+
+/**
+ * One Clean Fan
+ * Fan can either be on (clean requested for 3 hours) or off
+ */
+export class DaikinOnePlusOneCleanFan {
+  private service: Service;
+  CurrentState!: CharacteristicValue;
+
+  constructor(
+    private readonly platform: DaikinOnePlusPlatform,
+    private readonly accessory: PlatformAccessory,
+    private readonly deviceId: string,
+    private readonly daikinApi: DaikinApi,
+  ) {
+
+    // set accessory information
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Daikin')
+      .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device.model)
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device.id)
+      .setCharacteristic(this.platform.Characteristic.FirmwareRevision, accessory.context.device.firmwareVersion);
+
+    // you can create multiple services for each accessory
+    this.service = this.accessory.getService(this.platform.Service.Fanv2)
+                    || this.accessory.addService(this.platform.Service.Fanv2);
+
+    // set the service name, this is what is displayed as the default name on the Home app
+    this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+
+    this.service.getCharacteristic(this.platform.Characteristic.Active)
+      .onGet(this.handleActiveGet.bind(this))
+      .onSet(this.handleActiveSet.bind(this));
+  }
+
+  updateValues() {
+    const value = this.handleActiveGet();
+    this.service.updateCharacteristic(this.platform.Characteristic.Active, value);
+    setTimeout(()=>this.updateValues(), 2000);
+  }
+
+  /**
+   * Handle requests to get the current value of the "On" characteristic
+   */
+  handleActiveGet() {
+    return this.daikinApi.deviceHasData(this.deviceId) &&
+      this.daikinApi.getOneCleanFanActive(this.deviceId)
+      ? this.platform.Characteristic.Active.ACTIVE
+      : this.platform.Characteristic.Active.INACTIVE;
+  }
+
+  /**
+   * Handle requests to set the "On" characteristic
+   */
+  async handleActiveSet(value: CharacteristicValue) {
+    this.platform.log.debug('One Clean Fan', this.accessory.displayName, '- Set One Clean Fan State:', value);
+    await this.daikinApi.setOneCleanFanActive(this.deviceId, value === this.platform.Characteristic.Active.ACTIVE);
+  }
+}


### PR DESCRIPTION
One Clean is an on/off toggle on the thermostat allowing the user to
request the blower to run continuously for 3h to clean the air.

![image](https://user-images.githubusercontent.com/691152/146666801-94046018-b3ca-4919-844c-e87895730e51.png)


Also relevant for https://github.com/jeffschubert/homebridge-daikin-oneplus/issues/9.