### PR TITLE
Thermostat: Add heating and cooling threshold

### DIFF
--- a/src/daikinapi.ts
+++ b/src/daikinapi.ts
@@ -240,6 +240,16 @@ export class DaikinApi{
       }
     }
 
+    heatingThresholdTemperature(deviceId: string): number {
+      const device = this._devices.find(e=>e.id===deviceId);
+      return device.data.hspActive;
+    }
+
+    coolingThresholdTemperature(deviceId: string): number {
+      const device = this._devices.find(e=>e.id===deviceId);
+      return device.data.cspActive;
+    }
+
     getCurrentHumidity(deviceId: string): number {
       const device = this._devices.find(e=>e.id===deviceId);
       return device.data.humIndoor;
@@ -290,56 +300,31 @@ export class DaikinApi{
       return device.data.geofencingAway && device.data.geofencingEnabled;
     }
 
-    async setTargetTemp(deviceId: string, requestedTemp: number): Promise<boolean>{
+    async setTargetTemps(deviceId: string, targetTemp?: number, heatThreshold?: number, coolThreshold?: number): Promise<boolean>{
       const deviceData = await this.getDeviceData(deviceId);
       if(!deviceData){
         this.log(LoggerLevel.INFO, 'Device data could not be retrieved. Unable to set target temp.');
         return false;
       }
 
-      let requestedData = {};
-      let autoHsp = deviceData.hspHome;
-      switch(deviceData.mode){
+
+      let requestedData;
+      switch (deviceData.mode) {
         case 1: //heat
-          if(deviceData.schedEnabled){
-            requestedData = {
-              schedOverride: 1, 
-              hspHome: requestedTemp,
-            };
-          } else{
-            requestedData = {hspHome: requestedTemp};
-          }
+          requestedData = {
+            hspHome: targetTemp || heatThreshold,
+          };
           break;
         case 2: //cool
-          if(deviceData.schedEnabled){
-            requestedData = {
-              schedOverride: 1, 
-              cspHome: requestedTemp,
-            };
-          } else{
-            requestedData = {cspHome: requestedTemp};
-          }
+          requestedData = {
+            cspHome: targetTemp || coolThreshold,
+          };
           break;
         case 3: //auto
-          //In auto mode, also set heating set point if it would be too close to the requested temp
-          autoHsp = deviceData.hspHome + deviceData.tempDeltaMin >= requestedTemp 
-            ? requestedTemp - deviceData.tempDeltaMin 
-            : deviceData.hspHome;
-          //TODO: Come up with a way to detect when the requestedTemp is intended by the user to be the heating set point instead.
-          // i.e. it is winter and they're wanting to make it warmer instead of cooler. Daikin app allows setting both in auto mode
-          //   but HomeKit only allows setting a single temp
-          if(deviceData.schedEnabled){
-            requestedData = {
-              schedOverride: 1, 
-              cspHome: requestedTemp,
-              hspHome: autoHsp,
-            };
-          } else{
-            requestedData = {
-              cspHome: requestedTemp,
-              hspHome: autoHsp,
-            };
-          }
+          requestedData = {
+            hspHome: heatThreshold,
+            cspHome: coolThreshold,
+          };
           break;
         case 4: //emrg heat
           this.log(LoggerLevel.INFO, 'Device is in Emergency Heat. Unable to set target temp.');
@@ -348,7 +333,12 @@ export class DaikinApi{
           this.log(LoggerLevel.INFO, `Device is in an unknown state: ${deviceData.mode}. Unable to set target temp.`);
           return false;
       }
-      this.log(LoggerLevel.DEBUG, 'setTargetTemp-> requestedData: ', requestedData);
+
+      if(deviceData.schedEnabled){
+        requestedData.schedOverride = 1;
+      }
+
+      this.log(LoggerLevel.DEBUG, 'setTargetTemps-> requestedData: ', requestedData);
       return axios.put(`https://api.daikinskyport.com/deviceData/${deviceId}`, 
         requestedData, {
           headers: {

--- a/src/platformThermostat.ts
+++ b/src/platformThermostat.ts
@@ -16,6 +16,8 @@ export class DaikinOnePlusThermostat {
   TargetHeatingCoolingState!: CharacteristicValue;
   CurrentTemperature!: CharacteristicValue;
   TargetTemperature!: CharacteristicValue;
+  CoolingThresholdTemperature!: CharacteristicValue;
+  HeatingThresholdTemperature!: CharacteristicValue;
   TemperatureDisplayUnits!: CharacteristicValue;
   CurrentRelativeHumidity!: CharacteristicValue;
   TargetRelativeHumidity!: CharacteristicValue;
@@ -63,6 +65,18 @@ export class DaikinOnePlusThermostat {
       })
       .onSet(this.handleTargetTemperatureSet.bind(this));
 
+    this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .onGet(()=>{
+        return this.CoolingThresholdTemperature!;
+      })
+      .onSet(this.handleCoolingThresholdTemperatureSet.bind(this));
+
+    this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .onGet(()=>{
+        return this.HeatingThresholdTemperature!;
+      })
+      .onSet(this.handleHeatingThresholdTemperatureSet.bind(this));
+
     this.service.getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
       .onGet(()=>{
         return this.TemperatureDisplayUnits!;
@@ -89,6 +103,8 @@ export class DaikinOnePlusThermostat {
       this.TargetHeatingCoolingState = this.handleTargetHeatingCoolingStateGet();
       this.CurrentTemperature = this.handleCurrentTemperatureGet();
       this.TargetTemperature = this.handleTargetTemperatureGet();
+      this.HeatingThresholdTemperature = this.handleHeatingThresholdTemperatureGet();
+      this.CoolingThresholdTemperature = this.handleCoolingThresholdTemperatureGet();
       this.TemperatureDisplayUnits = this.handleTemperatureDisplayUnitsGet();
       this.CurrentRelativeHumidity = this.handleCurrentHumidityGet();
       this.TargetRelativeHumidity = this.handleTargetHumidityGet();
@@ -104,6 +120,18 @@ export class DaikinOnePlusThermostat {
       }
       if (this.TargetTemperature !== undefined) {
         this.service.updateCharacteristic(this.platform.Characteristic.TargetTemperature, this.TargetTemperature);
+      }
+      if (
+        this.TargetHeatingCoolingState === this.platform.Characteristic.TargetHeatingCoolingState.AUTO &&
+        this.CoolingThresholdTemperature !== undefined
+      ) {
+        this.service.updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, this.CoolingThresholdTemperature);
+      }
+      if (
+        this.TargetHeatingCoolingState === this.platform.Characteristic.TargetHeatingCoolingState.AUTO &&
+        this.HeatingThresholdTemperature !== undefined
+      ) {
+        this.service.updateCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature, this.HeatingThresholdTemperature);
       }
       if(this.TemperatureDisplayUnits !== undefined){
         this.service.updateCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits, this.TemperatureDisplayUnits);
@@ -201,6 +229,30 @@ export class DaikinOnePlusThermostat {
     this.platform.log.debug('Thermostat', this.accessory.displayName, '- Get TargetTemperature:', targetTemp);
     return targetTemp;
   }
+
+  handleHeatingThresholdTemperatureGet(): CharacteristicValue {
+    let temp = this.daikinApi.heatingThresholdTemperature(this.deviceId);
+    // set this to a valid value for CurrentTemperature
+    if(temp < 0) {
+      temp = 0;
+    } else if (temp > 25) {
+      temp = 25;
+    }
+    this.platform.log.debug('Thermostat', this.accessory.displayName, '- Get HeatingThresholdTemperature:', temp);
+    return temp;
+  }
+
+  handleCoolingThresholdTemperatureGet(): CharacteristicValue {
+    let temp = this.daikinApi.coolingThresholdTemperature(this.deviceId);
+    // set this to a valid value for CurrentTemperature
+    if(temp < 10) {
+      temp = 10;
+    } else if (temp > 35) {
+      temp = 35;
+    }
+    this.platform.log.debug('Thermostat', this.accessory.displayName, '- Get CoolingThresholdTemperature:', temp);
+    return temp;
+  }
   
   /**
    * Handle requests to get the current value of the "Temperature Display Units" characteristic
@@ -284,7 +336,25 @@ export class DaikinOnePlusThermostat {
   async handleTargetTemperatureSet(value: CharacteristicValue) {
     this.platform.log.debug('Thermostat', this.accessory.displayName, '- Set TargetTemperature:', value);
     this.TargetTemperature = value;
-    await this.daikinApi.setTargetTemp(this.deviceId, Number(value));
+    await this.daikinApi.setTargetTemps(this.deviceId, Number(value));
+  }
+
+  /**
+   * Handle requests to set the "Cooling Threshold Temperature" characteristic
+   */
+  async handleCoolingThresholdTemperatureSet(value: CharacteristicValue) {
+    this.platform.log.debug('Thermostat', this.accessory.displayName, '- Set CoolingThresholdTemperature:', value);
+    this.CoolingThresholdTemperature = value;
+    await this.daikinApi.setTargetTemps(this.deviceId, undefined, undefined, Number(value));
+  }
+
+  /**
+   * Handle requests to set the "Heating Threshold Temperature" characteristic
+   */
+  async handleHeatingThresholdTemperatureSet(value: CharacteristicValue) {
+    this.platform.log.debug('Thermostat', this.accessory.displayName, '- Set HeatingThresholdTemperature:', value);
+    this.HeatingThresholdTemperature = value;
+    await this.daikinApi.setTargetTemps(this.deviceId, undefined, Number(value), undefined);
   }
   
   /**

--- a/src/platformThermostat.ts
+++ b/src/platformThermostat.ts
@@ -63,19 +63,32 @@ export class DaikinOnePlusThermostat {
       .onGet(()=>{
         return this.TargetTemperature!;
       })
-      .onSet(this.handleTargetTemperatureSet.bind(this));
+      .onSet(this.handleTargetTemperatureSet.bind(this))
+      .setProps({
+        minStep: 0.5,
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
       .onGet(()=>{
         return this.CoolingThresholdTemperature!;
       })
-      .onSet(this.handleCoolingThresholdTemperatureSet.bind(this));
+      .onSet(this.handleCoolingThresholdTemperatureSet.bind(this))
+      .setProps({
+        minValue: 12,
+        maxValue: 32,
+        minStep: 0.5,
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
       .onGet(()=>{
         return this.HeatingThresholdTemperature!;
       })
-      .onSet(this.handleHeatingThresholdTemperatureSet.bind(this));
+      .onSet(this.handleHeatingThresholdTemperatureSet.bind(this))
+      .setProps({
+        minValue: 10,
+        maxValue: 30,
+        minStep: 0.5,
+      });
 
     this.service.getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
       .onGet(()=>{
@@ -114,6 +127,20 @@ export class DaikinOnePlusThermostat {
       }
       if(this.TargetHeatingCoolingState !== undefined){
         this.service.updateCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState, this.TargetHeatingCoolingState);
+      }
+      if (this.TargetHeatingCoolingState === this.platform.Characteristic.TargetHeatingCoolingState.HEAT) {
+        this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+          .setProps({
+            minValue: 10,
+            maxValue: 30,
+          });
+      }
+      if (this.TargetHeatingCoolingState === this.platform.Characteristic.TargetHeatingCoolingState.COOL) {
+        this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+          .setProps({
+            minValue: 12,
+            maxValue: 32,
+          });
       }
       if (this.CurrentTemperature !== undefined) {
         this.service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, this.CurrentTemperature);


### PR DESCRIPTION
Allows Homekit users to set the heating and cooling threshold independently in auto mode. Fixes #11.

![image](https://user-images.githubusercontent.com/691152/146670561-20bb7e44-d91b-4782-a9a0-a11ca286d537.png)

