### PR TITLE
Update device context for existing accessories

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -158,6 +158,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       if (existingAccessory) {
         // the accessory already exists
         existingAccessory.displayName = dName;
+        existingAccessory.context.device = device;
         this.log.info('Restoring existing away switch from cache:', existingAccessory.displayName);
         new DaikinOnePlusAwaySwitch(this, existingAccessory, device.id, this.daikinApi, dName);
       } else {
@@ -188,6 +189,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
         if (existingAccessory) {
         // the accessory already exists
           existingAccessory.displayName = dName;
+          existingAccessory.context.device = device;
           this.log.info('Restoring existing indoor Air Quality sensor from cache:', existingAccessory.displayName);
           new DaikinOnePlusAQSensor(this, existingAccessory, device.id, this.daikinApi, true, dName);
         } else {
@@ -223,6 +225,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
         if (existingAccessory) {
         // the accessory already exists
           existingAccessory.displayName = dName;
+          existingAccessory.context.device = device;
           this.log.info('Restoring existing outdoor Air Quality sensor from cache:', existingAccessory.displayName);
           new DaikinOnePlusAQSensor(this, existingAccessory, device.id, this.daikinApi, false, dName);
         } else {
@@ -255,6 +258,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       if (existingAccessory) {
       // the accessory already exists
         existingAccessory.displayName = dName;
+        existingAccessory.context.device = device;
         this.log.info('Restoring existing indoor humidity sensor from cache:', existingAccessory.displayName);
         new DaikinOnePlusHumidity(this, existingAccessory, device.id, this.daikinApi, true);
       } else {
@@ -284,6 +288,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       if (existingAccessory) {
       // the accessory already exists
         existingAccessory.displayName = dName;
+        existingAccessory.context.device = device;
         this.log.info('Restoring existing outdoor humidity sensor from cache:', existingAccessory.displayName);
         new DaikinOnePlusHumidity(this, existingAccessory, device.id, this.daikinApi, false);
       } else {
@@ -312,6 +317,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       if (existingAccessory) {
         // the accessory already exists
         existingAccessory.displayName = dName;
+        existingAccessory.context.device = device;
         this.log.info('Restoring existing thermostat from cache:', existingAccessory.displayName);
         new DaikinOnePlusThermostat(this, existingAccessory, device.id, this.daikinApi);
       } else {


### PR DESCRIPTION
Otherwise properties like the firmware version are never updated in Homekit. Small bug fix, I noticed that after my thermostat updated the firmware version in homekit remained the old one.