### PR TITLE
Add Eve app history support via fakegato-history

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "one+",
     "oneplus"
   ],
+  "dependencies": {
+    "fakegato-history": "^0.6.7"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/node": "^20.18.0",

--- a/src/fakegato-history.d.ts
+++ b/src/fakegato-history.d.ts
@@ -1,0 +1,45 @@
+declare module 'fakegato-history' {
+  import { API, Logging, PlatformAccessory } from 'homebridge';
+
+  interface FakeGatoHistoryOptions {
+    size?: number;
+    storage?: 'fs' | 'googleDrive';
+    path?: string;
+    folder?: string;
+    keyPath?: string;
+    disableTimer?: boolean;
+    disableRepeatLastData?: boolean;
+    log?: Logging;
+  }
+
+  interface HistoryEntry {
+    time: number;
+    currentTemp?: number;
+    setTemp?: number;
+    valvePosition?: number;
+    temp?: number;
+    humidity?: number;
+    ppm?: number;
+    pressure?: number;
+    power?: number;
+    status?: number;
+    voc?: number;
+    lux?: number;
+  }
+
+  class FakeGatoHistoryService {
+    constructor(
+      accessoryType: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      accessory: PlatformAccessory<any>,
+      options?: FakeGatoHistoryOptions | number,
+    );
+    addEntry(entry: HistoryEntry): void;
+    getInitialTime(): number;
+    isHistoryLoaded(): boolean;
+  }
+
+  function fakegato(api: API): typeof FakeGatoHistoryService;
+
+  export default fakegato;
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,5 @@
 import { API, APIEvent, Characteristic, DynamicPlatformPlugin, Logging, PlatformAccessory, PlatformConfig, Service } from 'homebridge';
+import fakegato from 'fakegato-history';
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { DaikinOnePlusThermostat } from './platformThermostat.js';
@@ -29,6 +30,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
 
   public readonly Service: typeof Service;
   public readonly Characteristic: typeof Characteristic;
+  public readonly FakeGatoHistoryService: ReturnType<typeof fakegato>;
 
   private readonly daikinApi: DaikinApi;
   private discoverTimer: NodeJS.Timeout | undefined;
@@ -40,6 +42,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
     this.log.debug = this.debug.bind(this);
     this.Service = this.api.hap.Service;
     this.Characteristic = this.api.hap.Characteristic;
+    this.FakeGatoHistoryService = fakegato(this.api);
 
     //Don't start if not configured
     if (!config) {

--- a/src/platformThermostat.ts
+++ b/src/platformThermostat.ts
@@ -1,6 +1,6 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { DaikinApi } from './daikinapi.js';
-import { AccessoryContext, ThermostatMode } from './types.js';
+import { AccessoryContext, EquipmentStatus, ThermostatMode } from './types.js';
 import { DaikinOnePlusPlatform } from './platform.js';
 
 /**
@@ -9,6 +9,7 @@ import { DaikinOnePlusPlatform } from './platform.js';
  */
 export class DaikinOnePlusThermostat {
   private service: Service;
+  private loggingService: InstanceType<DaikinOnePlusPlatform['FakeGatoHistoryService']>;
 
   public constructor(
     private readonly platform: DaikinOnePlusPlatform,
@@ -107,6 +108,11 @@ export class DaikinOnePlusThermostat {
       })
       .onSet(this.handleTargetHumiditySet.bind(this));
 
+    this.loggingService = new this.platform.FakeGatoHistoryService('thermo', this.accessory, {
+      log: this.platform.log,
+      storage: 'fs',
+    });
+
     this.daikinApi.addListener(this.deviceId, this.updateValues.bind(this));
   }
 
@@ -141,6 +147,20 @@ export class DaikinOnePlusThermostat {
     this.service.updateCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits, this.handleTemperatureDisplayUnitsGet());
     this.service.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.handleCurrentHumidityGet());
     this.service.updateCharacteristic(this.platform.Characteristic.TargetRelativeHumidity, this.handleTargetHumidityGet());
+
+    const currentTemp = this.daikinApi.getCurrentTemp(this.deviceId);
+    const setTemp = this.daikinApi.getTargetTemp(this.deviceId);
+    const status = this.daikinApi.getCurrentStatus(this.deviceId);
+    const isRunning =
+      status === EquipmentStatus.HEATING ||
+      status === EquipmentStatus.COOLING ||
+      status === EquipmentStatus.OVERCOOL_DEHUMIDIFYING;
+    this.loggingService.addEntry({
+      time: Math.round(Date.now() / 1000),
+      currentTemp,
+      setTemp,
+      valvePosition: isRunning ? 100 : 0,
+    });
   }
 
   /**


### PR DESCRIPTION
Closes #68

## Summary

- Adds `fakegato-history` as a runtime dependency
- Initializes `FakeGatoHistoryService` once at the platform level in `platform.ts`
- Attaches a `"thermo"` type history service to each thermostat accessory in `platformThermostat.ts`
- Adds a TypeScript declaration file for the untyped JS library

On every data refresh (~every 3 minutes), each thermostat logs:
- **Current temperature** (indoor, °C)
- **Set temperature** (active setpoint — heat SP for heat/auto modes, cool SP for cool mode)
- **Valve position** (100% when actively heating or cooling, 0% when idle/fan-only)

History is persisted to disk so it survives Homebridge restarts.

## Test plan

- [ ] Homebridge starts without errors with the plugin loaded
- [ ] Both thermostats discovered and running normally
- [ ] Eve app shows temperature history graph for the thermostat accessory
- [ ] History persists across a Homebridge restart (check for `*_persist.json` files in the Homebridge storage directory)

> Note: screenshots showing Eve history in action will be added as a comment.