### PR TITLE
fix: clear schedOverride when Away is turned off with autoResumeSchedule

### DIFF
--- a/src/daikinapi.ts
+++ b/src/daikinapi.ts
@@ -669,8 +669,13 @@ export class DaikinApi {
       };
     } else {
       if (enableSchedule) {
+        //  schedOverride must be cleared here too. Clearing geofencingAway and
+        //  setting schedEnabled does NOT cancel an active manual or temp hold,
+        //  so without this the thermostat stays parked on the held setpoint
+        //  and never returns to the schedule the user just asked to resume.
         requestedData = {
           geofencingAway: false,
+          schedOverride: 0,
           schedEnabled: true,
         };
       } else {


### PR DESCRIPTION
## The problem

With `autoResumeSchedule` enabled, turning the Away switch **off** sends:

```js
{ geofencingAway: false, schedEnabled: true }
```

That clears Away, but it does not cancel an active manual or temp hold. `schedOverride` stays set, so the thermostat remains parked on the held setpoint and never returns to the schedule the user just asked to resume.

The practical effect: you set a temp hold, leave, come home, toggle Away off, and the thermostat silently stays on the hold.

## Verification

Tested against a Daikin ONETOUCH on firmware 4.0.17, writing raw payloads and reading state back after each one:

| Write | `schedOverride` | `cspActive` |
|---|---|---|
| hold at `cspHome` 25.3 (schedule says 23.3) | 1 | 25.3 |
| `{geofencingAway:false, schedEnabled:true}` ← **current behavior** | **1** | **25.3** |
| `{geofencingAway:false, schedEnabled:true, schedOverride:0}` ← this PR | **0** | **23.3** |

The third row is the fix: the override clears and the thermostat drops back to its scheduled setpoint. Note the setpoints do **not** need to be written in the same request for this to work — `cspHome` was still 25.3 when the override cleared, and the schedule correctly took back over.

## The change

One field added, in one branch:

```diff
       if (enableSchedule) {
         requestedData = {
           geofencingAway: false,
+          schedOverride: 0,
           schedEnabled: true,
         };
       } else {
```

Scoped deliberately to the `enableSchedule` branch. With `autoResumeSchedule` off the user has opted out of resuming the schedule, so that payload is left untouched.

`schedOverride` is already on `ThermostatData` and `ThermostatUpdate` is a `Partial`, so no type changes are needed. `npm run build` and `npm run lint --max-warnings=0` both pass.

## A testing gotcha worth knowing

The Skyport API is eventually consistent and takes **longer than 5 seconds** to reflect a write. Reading device state too soon returns the *previous* write's values, which makes one payload appear to have another's effect. I initially drew the wrong conclusion from 5-second waits. The numbers above come from polling until the value was stable across consecutive reads.

`setScheduleState(true)` already sends `schedOverride: 0` and behaves correctly, so no change is needed there.