### PR TITLE
feat: gzip-compress completed daily history files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
   * Version 4.1
     * Route device data to pluggable consumers, including a History File consumer that writes daily JSONL files (configurable path/retention)
     * Optionally attach raw Daikin API data, filtered to chosen fields
+  * Version 4.1.1
+    * History files are now gzip-compressed once their day ends, to reduce disk usage (enabled by default; configurable via Compress History Files)
 
 
 ## Known Issue

--- a/config.schema.json
+++ b/config.schema.json
@@ -164,6 +164,15 @@
         "condition": {
           "functionBody": "return model.enableHistory === true"
         }
+      },
+      "compressHistoryFiles": {
+        "title": "Compress History Files",
+        "type": "boolean",
+        "description": "Compress each daily history file with gzip once its day has ended, to reduce disk usage. The current day's file is always kept uncompressed while it's being written. Defaults to true.",
+        "default": true,
+        "condition": {
+          "functionBody": "return model.enableHistory === true"
+        }
       }
     }
   },
@@ -224,6 +233,7 @@
         "enableHistory",
         "storagePath",
         "retentionDays",
+        "compressHistoryFiles",
         "recordRawData",
         "rawDataFields"
       ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Daikin One+",
   "name": "homebridge-daikin-oneplus",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Control a Daikin One+ thermostat.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/historyStore.ts
+++ b/src/historyStore.ts
@@ -35,6 +35,7 @@ export class HistoryStore {
         new JsonlFileHistoryConsumer(this.log, {
           storagePath: this.options.storagePath,
           retentionDays: (this.options.retentionDays as number) ?? 7,
+          compressHistoryFiles: this.options.compressHistoryFiles ?? true,
         }),
       );
     }

--- a/src/jsonlFileHistoryConsumer.ts
+++ b/src/jsonlFileHistoryConsumer.ts
@@ -117,10 +117,14 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     }
   }
 
-  /** Runs the periodic upkeep: compress finished days, then prune whatever falls outside retention. */
+  /**
+   * Runs the periodic upkeep: prune first so anything already outside the
+   * retention window is deleted before we'd otherwise waste time compressing
+   * it, then compress whatever finished days remain.
+   */
   private async runMaintenance(): Promise<void> {
-    await this.compressCompletedDays();
     await this.pruneOldEntries();
+    await this.compressCompletedDays();
   }
 
   /**

--- a/src/jsonlFileHistoryConsumer.ts
+++ b/src/jsonlFileHistoryConsumer.ts
@@ -1,12 +1,19 @@
 import fs from 'node:fs/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
 import path from 'node:path';
+import zlib from 'node:zlib';
 import type { Logging } from 'homebridge';
 import { HistoryConsumer, ThermostatReading } from './types.js';
 
 export interface JsonlFileHistoryConsumerOptions {
   storagePath: string; // e.g. api.user.storagePath()
   retentionDays?: number; // default 7
+  compressHistoryFiles?: boolean; // default true
 }
+
+const PLAIN_EXT = '.jsonl';
+const GZ_EXT = '.jsonl.gz';
 
 /**
  * Reference HistoryConsumer implementation. Writes readings to local,
@@ -20,9 +27,10 @@ export interface JsonlFileHistoryConsumerOptions {
 export class JsonlFileHistoryConsumer implements HistoryConsumer {
   private readonly historyDir: string;
   private retentionDays: number;
+  private readonly compressHistoryFiles: boolean;
   private buffer: Map<string, ThermostatReading[]> = new Map();
   private flushTimer?: NodeJS.Timeout;
-  private pruneTimer?: NodeJS.Timeout;
+  private maintenanceTimer?: NodeJS.Timeout;
 
   public constructor(
     private readonly log: Logging,
@@ -30,13 +38,14 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
   ) {
     this.historyDir = path.join(options.storagePath, 'daikin-oneplus-history');
     this.retentionDays = options.retentionDays ?? 7;
+    this.compressHistoryFiles = options.compressHistoryFiles ?? true;
 
     this.log.info('JsonlFileHistoryConsumer initialized with retentionDays=%d, storagePath=%s', this.retentionDays, this.historyDir);
 
     const flushIntervalMs = 60_000;
     this.flushTimer = setInterval(() => void this.flush(), flushIntervalMs);
-    this.pruneTimer = setInterval(() => void this.pruneOldEntries(), 60 * 60 * 1000);
-    void this.pruneOldEntries(); // catch up on anything stale from while we were down
+    this.maintenanceTimer = setInterval(() => void this.runMaintenance(), 60 * 60 * 1000);
+    void this.runMaintenance(); // catch up on anything stale from while we were down
   }
 
   public onReading(reading: ThermostatReading): void {
@@ -55,7 +64,25 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
   }
 
   private filePathForDay(dayKey: string): string {
-    return path.join(this.historyDir, `history-${dayKey}.jsonl`);
+    return path.join(this.historyDir, `history-${dayKey}${PLAIN_EXT}`);
+  }
+
+  private gzFilePathForDay(dayKey: string): string {
+    return path.join(this.historyDir, `history-${dayKey}${GZ_EXT}`);
+  }
+
+  /** Extracts the day-key from a history filename, in either plain or compressed form. Returns null for anything else found in the directory. */
+  private dayKeyFromFilename(file: string): string | null {
+    if (!file.startsWith('history-')) {
+      return null;
+    }
+    if (file.endsWith(GZ_EXT)) {
+      return file.slice('history-'.length, -GZ_EXT.length);
+    }
+    if (file.endsWith(PLAIN_EXT)) {
+      return file.slice('history-'.length, -PLAIN_EXT.length);
+    }
+    return null;
   }
 
   private async flush(): Promise<void> {
@@ -79,6 +106,7 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     for (const [dayKey, readings] of pending) {
       const lines = readings.map(r => JSON.stringify(r)).join('\n') + '\n';
       try {
+        // Always append to the plain file — today's file is never compressed while still being written.
         await fs.appendFile(this.filePathForDay(dayKey), lines, 'utf8');
       } catch (err) {
         this.log.error(`Failed to write history file for ${dayKey}:`, err);
@@ -89,7 +117,56 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     }
   }
 
-  /** Reads every day-file whose date falls within [since, until]. */
+  /** Runs the periodic upkeep: compress finished days, then prune whatever falls outside retention. */
+  private async runMaintenance(): Promise<void> {
+    await this.compressCompletedDays();
+    await this.pruneOldEntries();
+  }
+
+  /**
+   * Gzips any plain .jsonl file whose day has ended (i.e. every file except
+   * today's), then removes the uncompressed original. Today's file is left
+   * alone since it's still being appended to.
+   */
+  private async compressCompletedDays(): Promise<void> {
+    if (!this.compressHistoryFiles) {
+      return;
+    }
+    const todayKey = this.dayKeyFor(Date.now());
+    let dayFiles: string[];
+    try {
+      dayFiles = await fs.readdir(this.historyDir);
+    } catch {
+      return; // nothing written yet
+    }
+
+    for (const file of dayFiles) {
+      if (!file.endsWith(PLAIN_EXT)) {
+        continue; // already compressed, or not one of ours
+      }
+      const dayKey = this.dayKeyFromFilename(file);
+      if (dayKey === null || dayKey >= todayKey) {
+        continue; // still being written today
+      }
+      await this.compressFile(file, dayKey);
+    }
+  }
+
+  private async compressFile(file: string, dayKey: string): Promise<void> {
+    const source = path.join(this.historyDir, file);
+    const dest = this.gzFilePathForDay(dayKey);
+    try {
+      await pipeline(createReadStream(source), zlib.createGzip(), createWriteStream(dest));
+      await fs.unlink(source);
+      this.log.debug('Compressed history file for %s', dayKey);
+    } catch (err) {
+      this.log.warn(`Failed to compress history file for ${dayKey}:`, err);
+      // Remove a partial .gz so the next maintenance pass retries cleanly instead of leaving a truncated file behind.
+      await fs.unlink(dest).catch(() => {});
+    }
+  }
+
+  /** Reads every day-file (compressed or not) whose date falls within [since, until]. */
   private async readRange(since: number, until: number = Date.now()): Promise<ThermostatReading[]> {
     let dayFiles: string[];
     try {
@@ -101,17 +178,15 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     const sinceKey = this.dayKeyFor(since);
     const untilKey = this.dayKeyFor(until);
 
-    const relevantFiles = dayFiles
-      .filter(f => f.startsWith('history-') && f.endsWith('.jsonl'))
-      .filter(f => {
-        const dayKey = f.slice('history-'.length, -'.jsonl'.length);
-        return dayKey >= sinceKey && dayKey <= untilKey;
-      });
+    const relevantFiles = dayFiles.filter(f => {
+      const dayKey = this.dayKeyFromFilename(f);
+      return dayKey !== null && dayKey >= sinceKey && dayKey <= untilKey;
+    });
 
     const results: ThermostatReading[] = [];
     for (const file of relevantFiles) {
       try {
-        const raw = await fs.readFile(path.join(this.historyDir, file), 'utf8');
+        const raw = await this.readFileContents(file);
         for (const line of raw.split('\n')) {
           if (!line) {
             continue;
@@ -128,15 +203,24 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     return results.sort((a, b) => a.timestamp - b.timestamp);
   }
 
+  private async readFileContents(file: string): Promise<string> {
+    const filePath = path.join(this.historyDir, file);
+    if (file.endsWith(GZ_EXT)) {
+      const compressed = await fs.readFile(filePath);
+      return zlib.gunzipSync(compressed).toString('utf8');
+    }
+    return fs.readFile(filePath, 'utf8');
+  }
+
   public async query(deviceId: string, since: number, until: number = Date.now()): Promise<ThermostatReading[]> {
     const all = await this.readRange(since, until);
     return all.filter(r => r.deviceId === deviceId);
   }
 
   /**
-   * Deletes whole day-files outside the retention window — no read/rewrite needed.
-   * retentionDays counts calendar days inclusive of today, so 1 keeps only today's
-   * file, 7 keeps today plus the previous 6 days.
+   * Deletes whole day-files (compressed or not) outside the retention window —
+   * no read/rewrite needed. retentionDays counts calendar days inclusive of
+   * today, so 1 keeps only today's file, 7 keeps today plus the previous 6 days.
    */
   public async pruneOldEntries(): Promise<void> {
     if (this.retentionDays <= 0) {
@@ -150,16 +234,14 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
       return;
     }
     for (const file of dayFiles) {
-      if (!file.startsWith('history-') || !file.endsWith('.jsonl')) {
+      const dayKey = this.dayKeyFromFilename(file);
+      if (dayKey === null || dayKey >= cutoffKey) {
         continue;
       }
-      const dayKey = file.slice('history-'.length, -'.jsonl'.length);
-      if (dayKey < cutoffKey) {
-        try {
-          await fs.unlink(path.join(this.historyDir, file));
-        } catch (err) {
-          this.log.warn(`Failed to delete old history file ${file}:`, err);
-        }
+      try {
+        await fs.unlink(path.join(this.historyDir, file));
+      } catch (err) {
+        this.log.warn(`Failed to delete old history file ${file}:`, err);
       }
     }
   }
@@ -168,8 +250,8 @@ export class JsonlFileHistoryConsumer implements HistoryConsumer {
     if (this.flushTimer) {
       clearInterval(this.flushTimer);
     }
-    if (this.pruneTimer) {
-      clearInterval(this.pruneTimer);
+    if (this.maintenanceTimer) {
+      clearInterval(this.maintenanceTimer);
     }
     await this.flush(); // don't lose the last buffered minute
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -84,6 +84,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       enableHistory: !!config.enableHistory,
       storagePath: storagePath,
       retentionDays: config.retentionDays,
+      compressHistoryFiles: config.compressHistoryFiles === undefined ? true : !!config.compressHistoryFiles,
       recordRawData: !!config.recordRawData,
       rawDataFields: config.rawDataFields ?? '',
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,7 @@ export interface DaikinOptions {
   enableHistory: boolean;
   storagePath: string;
   retentionDays: number;
+  compressHistoryFiles: boolean;
   recordRawData: boolean;
   rawDataFields: string;
 }


### PR DESCRIPTION
## Summary

Reduces disk usage from the history file consumer. With `recordRawData` enabled, each reading can embed the full raw Daikin API payload (~30KB/line reported), which adds up fast across a day.

Adds a `compressHistoryFiles` config option (default `true`):

- Today's file is always written/appended as plain `.jsonl`, unchanged.
- An hourly maintenance pass (also run once at startup to catch up after downtime) gzips any *other* day's plain file to `.jsonl.gz` and removes the original. Compressing a whole finished day in one pass gets a much better ratio than compressing each 60s flush individually, and avoids the complexity of streaming/appending to an open gzip file.
- `pruneOldEntries()` and `query()`/`readRange()` now recognize both `.jsonl` and `.jsonl.gz` via a shared `dayKeyFromFilename()` helper, so retention and querying behave the same regardless of whether a given day has been compressed yet.
- A failed compression cleans up its partial `.gz` so the next hourly pass retries cleanly instead of leaving a truncated file around.

No new dependency — uses Node's built-in `zlib`, so it works identically across OS/architecture (no shelling out to a system `gzip` binary).

Bumps to `4.1.1`.

## Test plan

- [x] `npm run verify` (format:check + lint + build)
- [x] Manual smoke test: seeded a stale (>retention) plain file and a within-retention plain file, ran the consumer — confirmed the stale file is pruned, the other is compressed to valid gzip on the startup maintenance pass (`gzip -t` passes), and `query()` correctly decompresses and returns its contents byte-for-byte.