### PR TITLE
feat: Eve app history via a HistoryConsumer (proposal for #69)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -140,6 +140,12 @@
           "functionBody": "return model.recordRawData === true"
         }
       },
+      "enableEveHistory": {
+        "title": "Enable Eve App History",
+        "type": "boolean",
+        "description": "Enables temperature, setpoint, and valve position history for thermostats in the Eve app (requires the Eve for HomeKit app; not visible in the standard Home app). Defaults to false.",
+        "default": false
+      },
       "enableHistory": {
         "title": "Enable History Data",
         "type": "boolean",
@@ -230,6 +236,7 @@
       "expandable": true,
       "expanded": false,
       "items": [
+        "enableEveHistory",
         "enableHistory",
         "storagePath",
         "retentionDays",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "homebridge-daikin-oneplus",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-daikin-oneplus",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "fakegato-history": "^0.6.7"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@types/node": "^20.18.0",
@@ -583,6 +586,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -640,6 +652,35 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -691,6 +732,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -710,6 +757,35 @@
         "hookified": "^1.15.0",
         "keyv": "^5.6.0",
         "qified": "^0.10.1"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chalk": {
@@ -812,11 +888,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -850,12 +934,65 @@
         "node": ">=6"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1113,6 +1250,41 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fakegato-history": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/fakegato-history/-/fakegato-history-0.6.7.tgz",
+      "integrity": "sha512-gB5W5M7xI++vDUo7SEBVw/UP0+YULFSwalQw8lO33qY7cZVPUx3s8OTjA2plmzWU57D0bq5Tb3KtpKQ4Z7TZ0w==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "googleapis": ">39.1.0"
+      },
+      "engines": {
+        "homebridge": ">=0.4.0",
+        "node": ">=4.3.2"
+      }
+    },
+    "node_modules/fakegato-history/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/fakegato-history/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1142,6 +1314,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -1203,6 +1398,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -1240,6 +1447,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/futoin-hkdf": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
@@ -1248,6 +1464,71 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1294,6 +1575,74 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "180.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-180.0.0.tgz",
+      "integrity": "sha512-vuIkT4W09kDZn+dQbvSh1p2VU4DMZ7B/zLlxxlQgZjb06U0C6rA+5HSbZSlhp3DiSOZYHCOsuXJ+DUWIOQMVhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^11.0.0",
+        "googleapis-common": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-9.0.4.tgz",
+      "integrity": "sha512-fcI5bm1gN+9MNb+gvANRPFsxaJ07h/ZYvKCh6H3RoDJBUTwp5ySaCpCqnmX8gnGJUD/9bKmkacivRJT1g+xXyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.3.0",
+        "google-auth-library": "^11.0.0",
+        "google-logging-utils": "^2.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1333,6 +1682,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hashery": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
@@ -1344,6 +1705,18 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hexy": {
@@ -1400,6 +1773,19 @@
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.9",
@@ -1481,6 +1867,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1506,6 +1901,27 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -1573,6 +1989,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -1626,7 +2051,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -1656,6 +2080,44 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-persist": {
       "version": "0.0.12",
@@ -1728,6 +2190,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/optionator": {
@@ -1934,6 +2408,22 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1971,7 +2461,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2032,6 +2521,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -2278,6 +2839,21 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "one+",
     "oneplus"
   ],
+  "dependencies": {
+    "fakegato-history": "^0.6.7"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/node": "^20.18.0",

--- a/src/fakeGatoHistoryConsumer.ts
+++ b/src/fakeGatoHistoryConsumer.ts
@@ -1,0 +1,60 @@
+import type { API, Logging, PlatformAccessory } from 'homebridge';
+import fakegato from 'fakegato-history';
+import { AccessoryContext, EquipmentStatus, HistoryConsumer, ThermostatReading } from './types.js';
+
+/**
+ * Feeds readings into the Eve app's history graphs via fakegato-history.
+ * This is the only file in the plugin that references fakegato-history —
+ * everything else talks to it through the generic HistoryConsumer contract
+ * (onReading, onAccessoryRegistered) so the platform/accessory code has no
+ * idea Eve is involved.
+ *
+ * fakegato needs a PlatformAccessory to attach its service to, which
+ * HistoryConsumer.onReading() doesn't provide — that's what
+ * onAccessoryRegistered() is for. It's called once a device's accessory
+ * exists; we stash a logging service per deviceId and feed it from
+ * onReading() from then on. Readings that arrive before the accessory is
+ * registered (or for a device this consumer never saw registered, e.g.
+ * ignoreThermostat) are silently dropped.
+ */
+export class FakeGatoHistoryConsumer implements HistoryConsumer {
+  private readonly FakeGatoHistoryService: ReturnType<typeof fakegato>;
+  private readonly loggingServices = new Map<string, InstanceType<ReturnType<typeof fakegato>>>();
+
+  public constructor(
+    private readonly log: Logging,
+    api: API,
+  ) {
+    this.FakeGatoHistoryService = fakegato(api);
+  }
+
+  public onAccessoryRegistered(deviceId: string, accessory: PlatformAccessory<AccessoryContext>): void {
+    if (this.loggingServices.has(deviceId)) {
+      return; // already attached — onAccessoryRegistered can fire again on rediscovery/cache restore
+    }
+    const loggingService = new this.FakeGatoHistoryService('thermo', accessory, {
+      log: this.log,
+      storage: 'fs',
+    });
+    this.loggingServices.set(deviceId, loggingService);
+  }
+
+  public onReading(reading: ThermostatReading): void {
+    const loggingService = this.loggingServices.get(reading.deviceId);
+    if (!loggingService) {
+      return; // no accessory registered for this device yet
+    }
+
+    const isRunning =
+      reading.state === EquipmentStatus.HEATING.toString() ||
+      reading.state === EquipmentStatus.COOLING.toString() ||
+      reading.state === EquipmentStatus.OVERCOOL_DEHUMIDIFYING.toString();
+
+    loggingService.addEntry({
+      time: Math.round(reading.timestamp / 1000),
+      currentTemp: reading.indoorTemperature,
+      setTemp: reading.setpoint,
+      valvePosition: isRunning ? 100 : 0,
+    });
+  }
+}

--- a/src/fakegato-history.d.ts
+++ b/src/fakegato-history.d.ts
@@ -1,0 +1,46 @@
+declare module 'fakegato-history' {
+  import { API, Logging, PlatformAccessory } from 'homebridge';
+
+  interface FakeGatoHistoryOptions {
+    size?: number;
+    storage?: 'fs' | 'googleDrive';
+    path?: string;
+    folder?: string;
+    keyPath?: string;
+    disableTimer?: boolean;
+    disableRepeatLastData?: boolean;
+    log?: Logging;
+  }
+
+  interface HistoryEntry {
+    time: number;
+    currentTemp?: number;
+    setTemp?: number;
+    valvePosition?: number;
+    temp?: number;
+    humidity?: number;
+    ppm?: number;
+    pressure?: number;
+    power?: number;
+    status?: number;
+    voc?: number;
+    lux?: number;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  class FakeGatoHistoryService {
+    public constructor(
+      accessoryType: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      accessory: PlatformAccessory<any>,
+      options?: FakeGatoHistoryOptions | number,
+    );
+    public addEntry(entry: HistoryEntry): void;
+    public getInitialTime(): number;
+    public isHistoryLoaded(): boolean;
+  }
+
+  function fakegato(api: API): typeof FakeGatoHistoryService;
+
+  export default fakegato;
+}

--- a/src/historyStore.ts
+++ b/src/historyStore.ts
@@ -1,6 +1,15 @@
-import type { Logging } from 'homebridge';
-import { EquipmentStatus, HistoryConsumer, DaikinOptions, ThermostatData, ThermostatMode, ThermostatReading } from './types.js';
+import type { API, Logging, PlatformAccessory } from 'homebridge';
+import {
+  AccessoryContext,
+  EquipmentStatus,
+  HistoryConsumer,
+  DaikinOptions,
+  ThermostatData,
+  ThermostatMode,
+  ThermostatReading,
+} from './types.js';
 import { JsonlFileHistoryConsumer } from './jsonlFileHistoryConsumer.js';
+import { FakeGatoHistoryConsumer } from './fakeGatoHistoryConsumer.js';
 
 /**
  * Captures readings independent of any single consumer (files, Eve, MQTT...).
@@ -16,6 +25,7 @@ export class HistoryStore {
 
   public constructor(
     private readonly log: Logging,
+    private readonly api: API,
     private readonly options: DaikinOptions,
   ) {
     this.recordRawData = options.recordRawData ?? false;
@@ -39,11 +49,30 @@ export class HistoryStore {
         }),
       );
     }
+    if (this.options.enableEveHistory) {
+      this.registerConsumer(new FakeGatoHistoryConsumer(this.log, this.api));
+    }
     // Future consumers (MQTT, InfluxDB, etc.) can be registered here.
   }
 
   public registerConsumer(consumer: HistoryConsumer): void {
     this.consumers.push(consumer);
+  }
+
+  /**
+   * Called once a device's accessory has been created or restored from
+   * cache, so accessory-aware consumers (e.g. Eve history) can attach
+   * themselves to it. Safe to call more than once for the same deviceId —
+   * consumers are expected to no-op on repeat registrations.
+   */
+  public registerAccessory(deviceId: string, accessory: PlatformAccessory<AccessoryContext>): void {
+    for (const consumer of this.consumers) {
+      try {
+        consumer.onAccessoryRegistered?.(deviceId, accessory);
+      } catch (err) {
+        this.log.warn('History consumer failed to register accessory:', err);
+      }
+    }
   }
 
   public async record(deviceId: string, data: ThermostatData, setPoint: number): Promise<void> {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -87,6 +87,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
       compressHistoryFiles: config.compressHistoryFiles === undefined ? true : !!config.compressHistoryFiles,
       recordRawData: !!config.recordRawData,
       rawDataFields: config.rawDataFields ?? '',
+      enableEveHistory: !!config.enableEveHistory,
     };
 
     this.debug('Debug logging on. Expect lots of messages.');
@@ -94,7 +95,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
     this.debug('Using Include Device Name setting of %s.', this.config.includeDeviceName);
     this.debug('Finished initializing platform: %s', this.config.name);
 
-    this.historyStore = new HistoryStore(this.log, this.config);
+    this.historyStore = new HistoryStore(this.log, this.api, this.config);
 
     this.daikinApi = new DaikinApi(this.config.user, this.config.password, this.log, this.config.logRaw, this.historyStore);
 
@@ -479,6 +480,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
         existingAccessory.context.device = device;
         this.log.debug('Restoring existing thermostat from cache:', existingAccessory.displayName);
         new DaikinOnePlusThermostat(this, existingAccessory, device.id, this.daikinApi);
+        this.historyStore.registerAccessory(device.id, existingAccessory);
       } else {
         // the accessory does not yet exist, so we need to create it
         this.log.debug('Adding new thermostat:', dName);
@@ -486,6 +488,7 @@ export class DaikinOnePlusPlatform implements DynamicPlatformPlugin {
         const accessory = new this.api.platformAccessory<AccessoryContext>(dName, uuid);
         accessory.context.device = device;
         new DaikinOnePlusThermostat(this, accessory, device.id, this.daikinApi);
+        this.historyStore.registerAccessory(device.id, accessory);
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
     } else if (existingAccessory) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { PlatformAccessory } from 'homebridge';
+
 /**
  * Operating mode for the thermostat.
  * Maps to HomeKit's TargetHeatingCoolingState.
@@ -269,6 +271,7 @@ export interface DaikinOptions {
   compressHistoryFiles: boolean;
   recordRawData: boolean;
   rawDataFields: string;
+  enableEveHistory: boolean;
 }
 
 /**
@@ -294,6 +297,14 @@ export interface ThermostatReading {
 export interface HistoryConsumer {
   /** Called every time a new reading is captured. */
   onReading(reading: ThermostatReading): void | Promise<void>;
+  /**
+   * Optional hook called once a device's accessory has been created or
+   * restored from cache. Only consumers that need to attach something to
+   * the accessory itself (e.g. an Eve history service) need to implement
+   * this — it may be called more than once for the same deviceId across
+   * rediscovery/cache restores, so implementations must be idempotent.
+   */
+  onAccessoryRegistered?(deviceId: string, accessory: PlatformAccessory<AccessoryContext>): void;
   /** Optional cleanup hook, called when the platform shuts down. */
   destroy?(): void | Promise<void>;
 }


### PR DESCRIPTION
## Summary

Alternate implementation of Eve app history support (originally proposed in #69), reworked to fit the `HistoryConsumer` framework that shipped in 4.1 — and specifically to avoid leaking `fakegato-history` references into `platform.ts`/`platformThermostat.ts`.

## The design problem

`fakegato-history`'s `FakeGatoHistoryService` needs a `PlatformAccessory` to attach its service to, but `HistoryConsumer.onReading(reading)` only ever sees the normalized `ThermostatReading` — no accessory reference. Everything else about Eve support fits the existing `onReading()` contract fine; this was the one attachment point that didn't.

## The fix

- `HistoryConsumer` gains one small, generic, **optional** hook: `onAccessoryRegistered(deviceId, accessory)`. It's not Eve-specific — any future accessory-aware consumer can use it.
- `HistoryStore` gets a matching `registerAccessory()` pass-through, called once from `platform.ts`'s `discoverThermostat()` — the one place that already has the accessory. It's called on every discovery pass (including cache restores), so implementations must be idempotent.
- `FakeGatoHistoryConsumer` (new file) is the **only** place in the codebase that imports `fakegato-history` or its ambient `.d.ts`. It builds the `FakeGatoHistoryService` class from `api` at construction, attaches one instance per device in `onAccessoryRegistered`, and feeds it from `onReading()`.
- Gated behind a new `enableEveHistory` config toggle (default `false`).

`platform.ts` and `platformThermostat.ts` now know nothing about Eve beyond the generic registration hook and the config flag.

## Status

Posted as a draft for discussion with @TK-421-dev, the original author of #69 — not intending to merge this as-is. Happy to adjust the shape of `onAccessoryRegistered` (naming, whether it belongs on the base interface vs. a separate optional interface, etc.) based on feedback. Version isn't bumped and the README changelog isn't touched yet, pending that discussion.

## Test plan

- [x] `npm run verify` (format:check + lint + build)
- [ ] Manual test against a real Eve app / accessory (not yet done — feedback on the design first)